### PR TITLE
make signal endpoints return `{ received: true }` instead of `{ ok: 1 }`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ function createSignalEndpoint(router: express.Router, client: WorkflowClient, si
   router.put(`/signal/${signal.name}/:id`, express.json(), function(req: express.Request, res: express.Response) {
     const handle = client.getHandle(req.params.id);
     handle.signal(signal, req.body).
-      then(() => res.json({ ok: 1 })).
+      then(() => res.json({ received: true })).
       catch(err => res.status(500).json({ message: err.message }));
   });
 }

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -114,7 +114,7 @@ describe('createExpressMiddleware', function() {
       assert.strictEqual(res.data.result, 1500);
 
       res = await apiClient.put(`/signal/setDeadline/${workflowId}`, { deadline: Date.now() + 3000 });
-      assert.ok(res.data.ok);
+      assert.ok(res.data.received);
       
       res = await apiClient.get(`/query/timeLeft/${workflowId}`);
       assert.equal(typeof res.data.result, 'number');


### PR DESCRIPTION
Based on @lorensr 's comments from https://github.com/temporalio/documentation/pull/945. `{ ok: 1 }` is a bit too vague. I think `received: true` is a bit more indicative of what actually happened. `{ ok: 1 }` implies that the signal succeeded, which isn't necessarily true.